### PR TITLE
Add dataset examples and new block types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# NOTIONCLONE
-NOTIONCLONE
+# Notion Clone
+
+This project is a simplified Notion-like editor built with React and TypeScript.
+It includes a block editor, a command palette accessible via a button, and
+dynamic tables backed by a small data engine with sample datasets.
+
+Selecting **Data Table** from the command palette opens a dataset picker to
+choose which dataset to render as a dynamic table.
+
+Two sample datasets are included: "Ventas de Productos 2024" and
+"Inventario 2024". You can extend `data-engine.ts` with your own data.
+
+The command palette offers ten block types, including quote and divider
+blocks.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This project is a simplified Notion-like editor built with React and TypeScript.
 It includes a block editor, a command palette accessible via a button, and
 dynamic tables backed by a small data engine with sample datasets.
 
-Selecting **Data Table** from the command palette opens a dataset picker to
-choose which dataset to render as a dynamic table.
+Selecting **Data Table** from the command palette opens a dataset picker. Use
+the search box to filter datasets and choose one to render as a dynamic table.
 
 Two sample datasets are included: "Ventas de Productos 2024" and
 "Inventario 2024". You can extend `data-engine.ts` with your own data.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notion Clone</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import BlockEditor from './components/BlockEditor';
+
+export default function App() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Notion Clone</h1>
+      <BlockEditor />
+    </div>
+  );
+}

--- a/client/src/components/BlockEditor.tsx
+++ b/client/src/components/BlockEditor.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import CommandPalette from './CommandPalette';
+import DatasetSelector from './DatasetSelector';
+import { Block, createBlock } from '../lib/block-utils';
+import ParagraphBlock from './block-types/ParagraphBlock';
+import HeadingBlock from './block-types/HeadingBlock';
+import ListBlock from './block-types/ListBlock';
+import TodoBlock from './block-types/TodoBlock';
+import CodeBlock from './block-types/CodeBlock';
+import TableBlock from './block-types/TableBlock';
+import CalloutBlock from './block-types/CalloutBlock';
+import DynamicTableBlock from './block-types/DynamicTableBlock';
+import QuoteBlock from './block-types/QuoteBlock';
+import DividerBlock from './block-types/DividerBlock';
+
+export default function BlockEditor() {
+  const [blocks, setBlocks] = useState<Block[]>([]);
+  const [showPalette, setShowPalette] = useState(false);
+  const [selectDataset, setSelectDataset] = useState(false);
+
+  const renderBlock = (block: Block) => {
+    switch (block.type) {
+      case 'paragraph':
+        return <ParagraphBlock block={block} />;
+      case 'heading':
+        return <HeadingBlock block={block} />;
+      case 'list':
+        return <ListBlock block={block} />;
+      case 'todo':
+        return <TodoBlock block={block} />;
+      case 'code':
+        return <CodeBlock block={block} />;
+      case 'table':
+        return <TableBlock block={block} />;
+      case 'callout':
+        return <CalloutBlock block={block} />;
+      case 'quote':
+        return <QuoteBlock block={block} />;
+      case 'divider':
+        return <DividerBlock block={block} />;
+      case 'dynamic-table':
+        return <DynamicTableBlock block={block} />;
+      default:
+        return null;
+    }
+  };
+
+  const handleSelect = (type: string) => {
+    if (type === 'dynamic-table') {
+      setShowPalette(false);
+      setSelectDataset(true);
+      return;
+    }
+    const newBlock = createBlock(type, '');
+    setBlocks([...blocks, newBlock]);
+    setShowPalette(false);
+  };
+
+  const handleDataset = (datasetId: string) => {
+    const newBlock = createBlock('dynamic-table', datasetId);
+    setBlocks([...blocks, newBlock]);
+    setSelectDataset(false);
+  };
+
+  return (
+    <div>
+      {blocks.map((block) => (
+        <div key={block.id} style={{ margin: '0.5rem 0' }}>
+          {renderBlock(block)}
+        </div>
+      ))}
+      {showPalette && <CommandPalette onSelect={handleSelect} />}
+      {selectDataset && <DatasetSelector onSelect={handleDataset} />}
+      <button onClick={() => setShowPalette(!showPalette)}>+</button>
+    </div>
+  );
+}

--- a/client/src/components/CommandPalette.tsx
+++ b/client/src/components/CommandPalette.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const commands = [
+  { type: 'paragraph', label: 'Paragraph' },
+  { type: 'heading', label: 'Heading' },
+  { type: 'list', label: 'List' },
+  { type: 'todo', label: 'To-do' },
+  { type: 'code', label: 'Code' },
+  { type: 'callout', label: 'Callout' },
+  { type: 'table', label: 'Table' },
+  { type: 'dynamic-table', label: 'Data Table' },
+  { type: 'quote', label: 'Quote' },
+  { type: 'divider', label: 'Divider' },
+];
+
+export default function CommandPalette({ onSelect }: { onSelect: (type: string) => void }) {
+  return (
+    <div style={{ border: '1px solid #ccc', background: '#fff', padding: '0.5rem', position: 'absolute' }}>
+      {commands.map((cmd) => (
+        <div key={cmd.type} style={{ padding: '0.25rem 0', cursor: 'pointer' }} onClick={() => onSelect(cmd.type)}>
+          {cmd.label}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/DatasetSelector.tsx
+++ b/client/src/components/DatasetSelector.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Dataset, listDatasets } from '../lib/data-engine';
+
+export default function DatasetSelector({ onSelect }: { onSelect: (id: string) => void }) {
+  const datasets: Dataset[] = listDatasets();
+  return (
+    <div style={{ border: '1px solid #ccc', background: '#fff', padding: '0.5rem', position: 'absolute' }}>
+      {datasets.map((ds) => (
+        <div key={ds.id} style={{ padding: '0.25rem 0', cursor: 'pointer' }} onClick={() => onSelect(ds.id)}>
+          {ds.name}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/DatasetSelector.tsx
+++ b/client/src/components/DatasetSelector.tsx
@@ -1,10 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Dataset, listDatasets } from '../lib/data-engine';
 
 export default function DatasetSelector({ onSelect }: { onSelect: (id: string) => void }) {
-  const datasets: Dataset[] = listDatasets();
+  const [query, setQuery] = useState('');
+  const datasets: Dataset[] = listDatasets().filter((ds) =>
+    ds.name.toLowerCase().includes(query.toLowerCase())
+  );
   return (
     <div style={{ border: '1px solid #ccc', background: '#fff', padding: '0.5rem', position: 'absolute' }}>
+      <input
+        autoFocus
+        type="text"
+        placeholder="Search datasets..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        style={{ width: '100%', marginBottom: '0.5rem' }}
+      />
       {datasets.map((ds) => (
         <div key={ds.id} style={{ padding: '0.25rem 0', cursor: 'pointer' }} onClick={() => onSelect(ds.id)}>
           {ds.name}

--- a/client/src/components/block-types/CalloutBlock.tsx
+++ b/client/src/components/block-types/CalloutBlock.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+
+export default function CalloutBlock({ block }: { block: Block }) {
+  return (
+    <div style={{ borderLeft: '4px solid #aaa', padding: '0.5rem' }}>
+      {block.content}
+    </div>
+  );
+}

--- a/client/src/components/block-types/CodeBlock.tsx
+++ b/client/src/components/block-types/CodeBlock.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+
+export default function CodeBlock({ block }: { block: Block }) {
+  return (
+    <pre style={{ background: '#f0f0f0', padding: '1rem' }}>
+      <code>{block.content}</code>
+    </pre>
+  );
+}

--- a/client/src/components/block-types/DividerBlock.tsx
+++ b/client/src/components/block-types/DividerBlock.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+
+export default function DividerBlock({ block }: { block: Block }) {
+  return <hr />;
+}

--- a/client/src/components/block-types/DynamicTableBlock.tsx
+++ b/client/src/components/block-types/DynamicTableBlock.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+import { getDataset } from '../../lib/data-engine';
+
+export default function DynamicTableBlock({ block }: { block: Block }) {
+  const datasetId: string = block.content;
+  const dataset = getDataset(datasetId);
+
+  if (!dataset) return <div>No data</div>;
+
+  const keys = Object.keys(dataset.data[0] || {});
+
+  return (
+    <table border={1} cellPadding={4} cellSpacing={0}>
+      <thead>
+        <tr>
+          {keys.map((k) => (
+            <th key={k}>{k}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {dataset.data.map((row, idx) => (
+          <tr key={idx}>
+            {keys.map((k) => (
+              <td key={k}>{row[k]}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/client/src/components/block-types/HeadingBlock.tsx
+++ b/client/src/components/block-types/HeadingBlock.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+
+export default function HeadingBlock({ block }: { block: Block }) {
+  return <h2>{block.content}</h2>;
+}

--- a/client/src/components/block-types/ListBlock.tsx
+++ b/client/src/components/block-types/ListBlock.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+
+export default function ListBlock({ block }: { block: Block }) {
+  const items: string[] = block.content || [];
+  return (
+    <ul>
+      {items.map((item, idx) => (
+        <li key={idx}>{item}</li>
+      ))}
+    </ul>
+  );
+}

--- a/client/src/components/block-types/ParagraphBlock.tsx
+++ b/client/src/components/block-types/ParagraphBlock.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+
+export default function ParagraphBlock({ block }: { block: Block }) {
+  return <p>{block.content}</p>;
+}

--- a/client/src/components/block-types/QuoteBlock.tsx
+++ b/client/src/components/block-types/QuoteBlock.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+
+export default function QuoteBlock({ block }: { block: Block }) {
+  return <blockquote style={{ borderLeft: '4px solid #ccc', margin: 0, paddingLeft: '0.5rem' }}>{block.content}</blockquote>;
+}

--- a/client/src/components/block-types/TableBlock.tsx
+++ b/client/src/components/block-types/TableBlock.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+
+export default function TableBlock({ block }: { block: Block }) {
+  const rows: any[][] = block.content || [];
+  return (
+    <table border={1} cellPadding={4} cellSpacing={0}>
+      <tbody>
+        {rows.map((row, idx) => (
+          <tr key={idx}>
+            {row.map((cell, cidx) => (
+              <td key={cidx}>{cell}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/client/src/components/block-types/TodoBlock.tsx
+++ b/client/src/components/block-types/TodoBlock.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Block } from '../../lib/block-utils';
+
+export default function TodoBlock({ block }: { block: Block }) {
+  const todos: { text: string; done: boolean }[] = block.content || [];
+  return (
+    <ul>
+      {todos.map((t, idx) => (
+        <li key={idx} style={{ textDecoration: t.done ? 'line-through' : 'none' }}>
+          <input type="checkbox" checked={t.done} readOnly /> {t.text}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/client/src/lib/block-utils.ts
+++ b/client/src/lib/block-utils.ts
@@ -1,0 +1,20 @@
+export type Block = {
+  id: string;
+  type: string;
+  content?: any;
+};
+
+export function createBlock(type: string, content?: any): Block {
+  return { id: Math.random().toString(36).slice(2), type, content };
+}
+
+export function moveBlock(blocks: Block[], from: number, to: number) {
+  const updated = [...blocks];
+  const [moved] = updated.splice(from, 1);
+  updated.splice(to, 0, moved);
+  return updated;
+}
+
+export function removeBlock(blocks: Block[], index: number) {
+  return blocks.filter((_, i) => i !== index);
+}

--- a/client/src/lib/data-engine.ts
+++ b/client/src/lib/data-engine.ts
@@ -1,0 +1,35 @@
+export type Dataset = {
+  id: string;
+  name: string;
+  description: string;
+  data: Record<string, any>[];
+};
+
+export const datasets: Dataset[] = [
+  {
+    id: 'ventas-2024',
+    name: 'Ventas de Productos 2024',
+    description: 'Registros simples de productos vendidos',
+    data: [
+      { producto: 'Taza', unidades: 10, precio: 5.99, fecha: '2024-01-05' },
+      { producto: 'Camiseta', unidades: 7, precio: 15.0, fecha: '2024-01-08' },
+    ],
+  },
+  {
+    id: 'inventario-2024',
+    name: 'Inventario 2024',
+    description: 'Listado de productos en stock',
+    data: [
+      { item: 'Libro', stock: 50, precio: 9.99 },
+      { item: 'Bolígrafo', stock: 100, precio: 0.99 },
+    ],
+  },
+];
+
+export function listDatasets(): Dataset[] {
+  return datasets;
+}
+
+export function getDataset(id: string): Dataset | undefined {
+  return datasets.find((d) => d.id === id);
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  root: '.',
+  server: {
+    port: 5173
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "my-notion-clone",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["client/src"]
+}


### PR DESCRIPTION
## Summary
- add quote and divider block components
- support these new types in the editor
- provide an extra sample dataset
- document available datasets and block types

## Testing
- `npm run build` *(fails: Cannot find module 'react' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68447f0b384083338bd6001f2215402d